### PR TITLE
refactor: migrate state management to async with tokio-rusqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 # Test artifacts
 test-*.sh
+
+
+*.local.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,6 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1151,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rusqlite",
  "tokio-util",
  "toml 0.8.23",
  "tracing",
@@ -1587,6 +1603,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rusqlite"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc785c98d0c872455381e59be1f33a8f3a6b4e852544212e37601cc2ccb21d39"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 
 # Database
 rusqlite = { version = "0.30", features = [] }
+tokio-rusqlite = "0.5"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ impl Replicante {
         );
 
         // Initialize state manager
-        let state = StateManager::new(&config.database_path)?;
+        let state = StateManager::new(&config.database_path).await?;
         info!("State manager initialized");
 
         // Record birth

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,109 +1,145 @@
-use anyhow::Result;
-use rusqlite::{Connection, OptionalExtension, params};
+use anyhow::{Context, Result};
+use rusqlite::{OptionalExtension, params};
 use serde_json::Value;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use tokio_rusqlite::Connection;
 use tracing::{debug, info};
 
 pub struct StateManager {
-    conn: Arc<Mutex<Connection>>,
+    conn: Arc<Connection>,
 }
 
 impl StateManager {
-    pub fn new(database_path: &str) -> Result<Self> {
-        let conn = Connection::open(database_path)?;
+    pub async fn new(database_path: &str) -> Result<Self> {
+        let conn = Connection::open(database_path)
+            .await
+            .context("Failed to open database connection")?;
 
         // Create tables
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS memory (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                key TEXT UNIQUE NOT NULL,
-                value TEXT NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )",
-            [],
-        )?;
+        conn.call(|conn| {
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS memory (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT UNIQUE NOT NULL,
+                    value TEXT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )",
+                [],
+            )?;
 
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS decisions (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                thought TEXT NOT NULL,
-                action TEXT NOT NULL,
-                result TEXT,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )",
-            [],
-        )?;
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS decisions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    thought TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    result TEXT,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )",
+                [],
+            )?;
 
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS capabilities (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                tool_name TEXT NOT NULL,
-                description TEXT,
-                last_used TIMESTAMP,
-                success_rate REAL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )",
-            [],
-        )?;
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS capabilities (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tool_name TEXT NOT NULL,
+                    description TEXT,
+                    last_used TIMESTAMP,
+                    success_rate REAL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )",
+                [],
+            )?;
+
+            Ok(())
+        })
+        .await
+        .context("Failed to create database tables")?;
 
         info!("Database initialized at: {database_path}");
 
         Ok(Self {
-            conn: Arc::new(Mutex::new(conn)),
+            conn: Arc::new(conn),
         })
     }
 
     pub async fn remember(&self, key: &str, value: Value) -> Result<()> {
         let value_str = serde_json::to_string(&value)?;
-        let conn = self.conn.lock().unwrap();
+        let key_clone = key.to_string();
 
-        // Insert or update
-        conn.execute(
-            "INSERT INTO memory (key, value) VALUES (?1, ?2)
-             ON CONFLICT(key) DO UPDATE SET 
-             value = excluded.value,
-             updated_at = CURRENT_TIMESTAMP",
-            params![key, value_str],
-        )?;
+        self.conn
+            .call(move |conn| {
+                // Insert or update
+                conn.execute(
+                    "INSERT INTO memory (key, value) VALUES (?1, ?2)
+                     ON CONFLICT(key) DO UPDATE SET 
+                     value = excluded.value,
+                     updated_at = CURRENT_TIMESTAMP",
+                    params![key_clone, value_str],
+                )?;
+                Ok(())
+            })
+            .await
+            .context("Failed to remember value")?;
 
-        debug!("Remembered: {key} = {value_str}");
+        debug!("Remembered: {key} = {value}");
         Ok(())
     }
 
     #[allow(dead_code)]
     pub async fn recall(&self, key: &str) -> Result<Option<Value>> {
-        let conn = self.conn.lock().unwrap();
+        let key_clone = key.to_string();
 
-        let mut stmt = conn.prepare("SELECT value FROM memory WHERE key = ?1")?;
-        let mut rows = stmt.query_map(params![key], |row| row.get::<_, String>(0))?;
+        let value_str_opt = self
+            .conn
+            .call(move |conn| {
+                let mut stmt = conn.prepare("SELECT value FROM memory WHERE key = ?1")?;
+                let mut rows = stmt.query_map(params![key_clone], |row| row.get::<_, String>(0))?;
 
-        if let Some(row) = rows.next() {
-            let value_str = row?;
-            let value: Value = serde_json::from_str(&value_str)?;
-            Ok(Some(value))
-        } else {
-            Ok(None)
+                if let Some(row) = rows.next() {
+                    let value_str = row?;
+                    Ok(Some(value_str))
+                } else {
+                    Ok(None)
+                }
+            })
+            .await
+            .context("Failed to recall value")?;
+
+        // Parse JSON outside the closure to avoid error type issues
+        match value_str_opt {
+            Some(value_str) => {
+                let value: Value = serde_json::from_str(&value_str)
+                    .context("Failed to parse stored JSON value")?;
+                Ok(Some(value))
+            }
+            None => Ok(None),
         }
     }
 
     pub async fn get_memory(&self) -> Result<Value> {
-        let conn = self.conn.lock().unwrap();
+        let memory = self
+            .conn
+            .call(|conn| {
+                let mut stmt = conn.prepare("SELECT key, value FROM memory")?;
+                let memory_iter = stmt.query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })?;
 
-        let mut stmt = conn.prepare("SELECT key, value FROM memory")?;
-        let memory_iter = stmt.query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+                let mut memory = serde_json::Map::new();
+                for entry in memory_iter {
+                    let (key, value_str) = entry?;
+                    if let Ok(value) = serde_json::from_str::<Value>(&value_str) {
+                        memory.insert(key, value);
+                    }
+                }
 
-        let mut memory = serde_json::Map::new();
-        for entry in memory_iter {
-            let (key, value_str) = entry?;
-            if let Ok(value) = serde_json::from_str::<Value>(&value_str) {
-                memory.insert(key, value);
-            }
-        }
+                Ok(Value::Object(memory))
+            })
+            .await
+            .context("Failed to get memory")?;
 
-        Ok(Value::Object(memory))
+        Ok(memory)
     }
 
     pub async fn record_decision(
@@ -112,48 +148,62 @@ impl StateManager {
         action: &str,
         result: Option<&str>,
     ) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let thought_clone = thought.to_string();
+        let action_clone = action.to_string();
+        let result_clone = result.map(|s| s.to_string());
 
-        conn.execute(
-            "INSERT INTO decisions (thought, action, result) VALUES (?1, ?2, ?3)",
-            params![thought, action, result],
-        )?;
+        self.conn
+            .call(move |conn| {
+                conn.execute(
+                    "INSERT INTO decisions (thought, action, result) VALUES (?1, ?2, ?3)",
+                    params![thought_clone, action_clone, result_clone],
+                )?;
+                Ok(())
+            })
+            .await
+            .context("Failed to record decision")?;
 
         debug!("Recorded decision: {thought} -> {action}");
         Ok(())
     }
 
     pub async fn get_recent_decisions(&self, limit: usize) -> Result<Vec<String>> {
-        let conn = self.conn.lock().unwrap();
+        let decisions = self
+            .conn
+            .call(move |conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT thought, action, result, created_at 
+                     FROM decisions 
+                     ORDER BY created_at DESC 
+                     LIMIT ?1",
+                )?;
 
-        let mut stmt = conn.prepare(
-            "SELECT thought, action, result, created_at 
-             FROM decisions 
-             ORDER BY created_at DESC 
-             LIMIT ?1",
-        )?;
+                let decisions = stmt.query_map(params![limit], |row| {
+                    let thought = row.get::<_, String>(0)?;
+                    let action = row.get::<_, String>(1)?;
+                    let result: Option<String> = row.get(2)?;
+                    let created_at = row.get::<_, String>(3)?;
 
-        let decisions = stmt.query_map(params![limit], |row| {
-            let thought = row.get::<_, String>(0)?;
-            let action = row.get::<_, String>(1)?;
-            let result: Option<String> = row.get(2)?;
-            let created_at = row.get::<_, String>(3)?;
+                    Ok(format!(
+                        "[{}] Thought: {} | Action: {} | Result: {}",
+                        created_at,
+                        thought,
+                        action,
+                        result.unwrap_or_else(|| "pending".to_string())
+                    ))
+                })?;
 
-            Ok(format!(
-                "[{}] Thought: {} | Action: {} | Result: {}",
-                created_at,
-                thought,
-                action,
-                result.unwrap_or_else(|| "pending".to_string())
-            ))
-        })?;
+                let mut results = Vec::new();
+                for decision in decisions {
+                    results.push(decision?);
+                }
 
-        let mut results = Vec::new();
-        for decision in decisions {
-            results.push(decision?);
-        }
+                Ok(results)
+            })
+            .await
+            .context("Failed to get recent decisions")?;
 
-        Ok(results)
+        Ok(decisions)
     }
 
     #[allow(dead_code)]
@@ -163,72 +213,90 @@ impl StateManager {
         description: Option<&str>,
         success: bool,
     ) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
+        let tool_name_clone = tool_name.to_string();
+        let description_clone = description.map(|s| s.to_string());
 
-        // Check if capability exists
-        let mut stmt =
-            conn.prepare("SELECT id, success_rate FROM capabilities WHERE tool_name = ?1")?;
-        let existing = stmt
-            .query_row(params![tool_name], |row| {
-                Ok((row.get::<_, i32>(0)?, row.get::<_, Option<f64>>(1)?))
+        self.conn
+            .call(move |conn| {
+                // Check if capability exists
+                let mut stmt =
+                    conn.prepare("SELECT id, success_rate FROM capabilities WHERE tool_name = ?1")?;
+                let existing = stmt
+                    .query_row(params![tool_name_clone], |row| {
+                        Ok((row.get::<_, i32>(0)?, row.get::<_, Option<f64>>(1)?))
+                    })
+                    .optional()?;
+
+                if let Some((id, current_rate)) = existing {
+                    // Update existing capability
+                    let new_rate = if let Some(rate) = current_rate {
+                        // Simple moving average
+                        (rate * 0.9) + (if success { 0.1 } else { 0.0 })
+                    } else if success {
+                        1.0
+                    } else {
+                        0.0
+                    };
+
+                    conn.execute(
+                        "UPDATE capabilities SET 
+                         description = COALESCE(?1, description),
+                         last_used = CURRENT_TIMESTAMP,
+                         success_rate = ?2
+                         WHERE id = ?3",
+                        params![description_clone, new_rate, id],
+                    )?;
+                } else {
+                    // Insert new capability
+                    conn.execute(
+                        "INSERT INTO capabilities (tool_name, description, last_used, success_rate) 
+                         VALUES (?1, ?2, CURRENT_TIMESTAMP, ?3)",
+                        params![
+                            tool_name_clone,
+                            description_clone,
+                            if success { 1.0 } else { 0.0 }
+                        ],
+                    )?;
+                }
+
+                Ok(())
             })
-            .optional()?;
-
-        if let Some((id, current_rate)) = existing {
-            // Update existing capability
-            let new_rate = if let Some(rate) = current_rate {
-                // Simple moving average
-                (rate * 0.9) + (if success { 0.1 } else { 0.0 })
-            } else if success {
-                1.0
-            } else {
-                0.0
-            };
-
-            conn.execute(
-                "UPDATE capabilities SET 
-                 description = COALESCE(?1, description),
-                 last_used = CURRENT_TIMESTAMP,
-                 success_rate = ?2
-                 WHERE id = ?3",
-                params![description, new_rate, id],
-            )?;
-        } else {
-            // Insert new capability
-            conn.execute(
-                "INSERT INTO capabilities (tool_name, description, last_used, success_rate) 
-                 VALUES (?1, ?2, CURRENT_TIMESTAMP, ?3)",
-                params![tool_name, description, if success { 1.0 } else { 0.0 }],
-            )?;
-        }
+            .await
+            .context("Failed to record capability")?;
 
         Ok(())
     }
 
     #[allow(dead_code)]
     pub async fn get_capabilities(&self) -> Result<Vec<(String, Option<String>, Option<f64>)>> {
-        let conn = self.conn.lock().unwrap();
+        let capabilities = self
+            .conn
+            .call(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT tool_name, description, success_rate 
+                     FROM capabilities 
+                     ORDER BY last_used DESC",
+                )?;
 
-        let mut stmt = conn.prepare(
-            "SELECT tool_name, description, success_rate 
-             FROM capabilities 
-             ORDER BY last_used DESC",
-        )?;
+                let capabilities = stmt.query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<f64>>(2)?,
+                    ))
+                })?;
 
-        let capabilities = stmt.query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, Option<String>>(1)?,
-                row.get::<_, Option<f64>>(2)?,
-            ))
-        })?;
+                let mut results = Vec::new();
+                for cap in capabilities {
+                    results.push(cap?);
+                }
 
-        let mut results = Vec::new();
-        for cap in capabilities {
-            results.push(cap?);
-        }
+                Ok(results)
+            })
+            .await
+            .context("Failed to get capabilities")?;
 
-        Ok(results)
+        Ok(capabilities)
     }
 }
 
@@ -240,9 +308,12 @@ mod tests {
     #[tokio::test]
     async fn test_state_manager() -> Result<()> {
         let temp_file = NamedTempFile::new()?;
-        let db_path = temp_file.path().to_str().unwrap();
+        let db_path = temp_file
+            .path()
+            .to_str()
+            .context("Failed to get temp file path")?;
 
-        let state = StateManager::new(db_path)?;
+        let state = StateManager::new(db_path).await?;
 
         // Test remember and recall
         state


### PR DESCRIPTION
## Summary
- Replaced synchronous `std::sync::Mutex` with `tokio-rusqlite` for proper async SQLite operations
- Eliminated all `.unwrap()` calls on mutex locks that could cause panics
- Improved error handling throughout the state management system

## Changes
- Added `tokio-rusqlite` dependency for async SQLite operations
- Replaced `std::sync::Mutex<Connection>` with `tokio_rusqlite::Connection`
- Converted `StateManager::new` to async function
- Wrapped all database operations in `.call()` closures for tokio-rusqlite
- Replaced all `.unwrap()` calls with proper error handling using `.context()`
- Updated tests to work with async StateManager

## Benefits
- **No more panics**: Eliminated dangerous `.unwrap()` calls that could panic on poisoned mutex
- **True async/await**: Proper async support throughout the state management system
- **Thread-safe**: SQLite operations are now thread-safe through tokio-rusqlite
- **Better debugging**: Error messages now include context for easier troubleshooting

## Test Plan
- [x] All existing tests pass
- [x] `cargo fmt` applied
- [x] `cargo clippy` passes with no warnings
- [x] Manually tested state operations work correctly