### PR TITLE
feat: add supervisor shutdown command and improve CLI clarity

### DIFF
--- a/src/bin/replicante.rs
+++ b/src/bin/replicante.rs
@@ -63,14 +63,17 @@ enum SupervisorCommands {
     /// Show supervisor status
     Status,
 
+    /// Shutdown the supervisor daemon
+    Shutdown,
+
     /// Stop an agent
-    Stop {
+    StopAgent {
         /// Agent ID to stop
         agent_id: String,
     },
 
     /// Emergency stop an agent
-    Kill {
+    KillAgent {
         /// Agent ID to kill
         agent_id: String,
     },
@@ -214,7 +217,16 @@ async fn main() -> Result<()> {
                 }
             }
 
-            SupervisorCommands::Stop { agent_id } => {
+            SupervisorCommands::Shutdown => {
+                let client =
+                    replicante::supervisor::async_client::AsyncSupervisorClient::new(None)?;
+                match client.shutdown().await {
+                    Ok(_) => println!("Successfully sent shutdown signal to supervisor"),
+                    Err(e) => eprintln!("Failed to shutdown supervisor: {e}"),
+                }
+            }
+
+            SupervisorCommands::StopAgent { agent_id } => {
                 let client =
                     replicante::supervisor::async_client::AsyncSupervisorClient::new(None)?;
                 match client.stop_agent(&agent_id).await {
@@ -223,7 +235,7 @@ async fn main() -> Result<()> {
                 }
             }
 
-            SupervisorCommands::Kill { agent_id } => {
+            SupervisorCommands::KillAgent { agent_id } => {
                 let client =
                     replicante::supervisor::async_client::AsyncSupervisorClient::new(None)?;
                 match client.kill_agent(&agent_id).await {

--- a/src/supervisor/async_client.rs
+++ b/src/supervisor/async_client.rs
@@ -252,4 +252,26 @@ impl AsyncSupervisorClient {
 
         Ok(stream)
     }
+
+    pub async fn shutdown(&self) -> Result<()> {
+        let url = format!("{base_url}/api/shutdown", base_url = self.base_url);
+        info!("Sending shutdown signal to supervisor");
+
+        let response = self
+            .client
+            .post(&url)
+            .send()
+            .await
+            .context("Failed to send shutdown request")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            error!("Shutdown request failed with {status}: {text}");
+            anyhow::bail!("Shutdown request failed with {status}");
+        }
+
+        info!("Supervisor shutdown initiated");
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds a proper shutdown command for the supervisor daemon and improves CLI command naming for better clarity.

## Changes
- Added `supervisor shutdown` command to gracefully stop the supervisor daemon
- Renamed `supervisor stop` to `supervisor stop-agent` for clarity
- Renamed `supervisor kill` to `supervisor kill-agent` for clarity
- Implemented shutdown endpoint in supervisor API (`/api/shutdown`)
- Added shutdown method to AsyncSupervisorClient

## Testing
Tested the shutdown functionality:
1. Started supervisor with `supervisor start --web-port 8092`
2. Verified it was running with `supervisor status`
3. Successfully shut it down with `supervisor shutdown`
4. Confirmed the supervisor process terminated gracefully

## Breaking Changes
- CLI commands `supervisor stop` and `supervisor kill` are now `supervisor stop-agent` and `supervisor kill-agent`