### PR TITLE
feat: add Gemini API support to OpenAI provider

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -115,12 +115,20 @@ impl OpenAIProvider {
             .api_key
             .clone()
             .or_else(|| std::env::var("OPENAI_API_KEY").ok())
-            .ok_or_else(|| anyhow::anyhow!("OpenAI API key not found"))?;
+            .or_else(|| std::env::var("GEMINI_API_KEY").ok())
+            .ok_or_else(|| anyhow::anyhow!("OpenAI/Gemini API key not found"))?;
 
-        let api_url = config
+        let mut api_url = config
             .api_url
             .clone()
             .unwrap_or_else(|| "https://api.openai.com/v1/chat/completions".to_string());
+
+        // Fix Gemini endpoint if needed
+        if api_url.contains("generativelanguage.googleapis.com")
+            && !api_url.contains("/chat/completions")
+        {
+            api_url = format!("{}/chat/completions", api_url.trim_end_matches('/'));
+        }
 
         Ok(Self {
             client: Client::builder()


### PR DESCRIPTION
## Summary
Adds support for Google Gemini models through the OpenAI-compatible API endpoint, enabling the use of advanced models like Gemini 2.5 Flash and 2.5 Pro.

## Changes
- Added support for `GEMINI_API_KEY` environment variable as a fallback option
- Automatically fixes Gemini API URLs to include the required `/chat/completions` endpoint
- Updated error messages to reflect support for both OpenAI and Gemini APIs

## Technical Details
The Gemini API provides an OpenAI-compatible endpoint at `https://generativelanguage.googleapis.com/v1beta/openai/`. This change detects when this URL is used and automatically appends `/chat/completions` if needed, ensuring compatibility with the existing OpenAI provider implementation.

## Testing
- All existing tests pass
- Manually tested with Gemini 2.5 Flash model in the Fedimint challenge
- Agent successfully connects and uses Gemini for reasoning

## Benefits
- Access to Gemini's latest models including 2.5 Flash (fast, efficient) and 2.5 Pro (advanced reasoning)
- No need for a separate Gemini provider - reuses existing OpenAI infrastructure
- Seamless switching between OpenAI and Gemini models via configuration

## Configuration Example
```toml
[llm]
provider = "openai"
model = "gemini-2.5-flash"
api_url = "https://generativelanguage.googleapis.com/v1beta/openai"
api_key = "YOUR_GEMINI_API_KEY"
temperature = 0.3
max_tokens = 8000
```