### PR TITLE
feat: enhance decision tracking beyond PR #23 with smart truncation

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -894,6 +894,8 @@ mod tests {
             summary: Some("Test completed successfully".to_string()),
             error: None,
             duration_ms: Some(123),
+            tool_name: None,
+            tool_output: None,
         };
 
         state.update_decision_result(decision_id, &result).await?;
@@ -1160,6 +1162,8 @@ mod tests {
             summary: Some("Operation completed".to_string()),
             error: None,
             duration_ms: Some(500),
+            tool_name: None,
+            tool_output: None,
         };
         state
             .update_decision_result(decision_id, &success_result)
@@ -1177,6 +1181,8 @@ mod tests {
             summary: None,
             error: Some("Connection timeout".to_string()),
             duration_ms: Some(30000),
+            tool_name: None,
+            tool_output: None,
         };
         state
             .update_decision_result(decision_id, &error_result)


### PR DESCRIPTION
## Summary
This PR builds upon PR #23's foundation by adding intelligent improvements to decision tracking and tool output handling.

## What PR #23 Added
PR #23 introduced `tool_name` and `tool_output` fields to DecisionResult, providing basic tool output visibility.

## What This PR Adds Beyond PR #23

### 1. Smart JSON-Aware Truncation
- **PR #23**: Basic string truncation at 2000 characters
- **This PR**: Intelligent truncation that:
  - Preserves JSON structure
  - Truncates individual fields over 1000 chars
  - Recursively handles nested objects
  - Adds metadata fields (`_truncated`, `_original_size`)

### 2. Error Handling for Failed Decisions
- **PR #23**: Decisions with invalid actions get NULL results
- **This PR**: Properly updates decisions with error results when parsing fails

### 3. Improved Parameter Serialization
- **PR #23**: Uses Debug format (`{:?}`) for parameters
- **This PR**: Uses proper JSON serialization for cleaner, readable output

### 4. Complete Tool Output for All Actions
- **PR #23**: Basic tool output for UseTool
- **This PR**: Comprehensive output for all action types:
  - Remember: includes key/value
  - Wait: includes waited_seconds
  - Explore: includes tools_discovered count and list
  - Errors: structured error output with tool name

### 5. Removed Redundant Memory Storage
- **PR #23**: Still stores tool results in memory
- **This PR**: Eliminates redundant `tool_result_*` memory entries

## Changes
- Enhanced smart truncation algorithm in `src/lib.rs`
- Added error result handling for invalid action formats
- Improved parameter display using JSON serialization
- Complete tool output for Remember, Wait, and Explore actions
- Updated test cases with new DecisionResult fields

## Test Plan
- [x] Unit tests pass with enhanced DecisionResult structure
- [x] Smart truncation preserves JSON structure
- [x] Invalid actions get proper error results (no NULL)
- [x] All action types store meaningful output
- [x] No redundant memory entries created

## Breaking Changes
None - backward compatible enhancements only