### PR TITLE
feat: preserve JSON structure in MCP tool results

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -736,12 +736,18 @@ impl MCPClient {
 
             let tool_result: ToolCallResult = serde_json::from_value(result)?;
 
-            // Convert tool result to simplified format
+            // Convert tool result to appropriate format
             if let Some(content) = tool_result.content
                 && !content.is_empty()
             {
                 // Extract text content from the first item
                 if let Some(ContentItem::Text { text }) = content.into_iter().next() {
+                    // Try to parse as JSON to preserve structure
+                    if let Ok(json_value) = serde_json::from_str::<Value>(&text) {
+                        // Return the parsed JSON directly to preserve all fields
+                        return Ok(json_value);
+                    }
+                    // Fall back to simple format if not valid JSON
                     return Ok(serde_json::json!({
                         "success": !tool_result.is_error.unwrap_or(false),
                         "content": text

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -748,6 +748,10 @@ impl MCPClient {
                         return Ok(json_value);
                     }
                     // Fall back to simple format if not valid JSON
+                    debug!(
+                        "Tool result is not valid JSON, using simplified format. Content preview: {}...",
+                        &text.chars().take(100).collect::<String>()
+                    );
                     return Ok(serde_json::json!({
                         "success": !tool_result.is_error.unwrap_or(false),
                         "content": text


### PR DESCRIPTION
## Summary
This PR enhances MCP tool result handling to preserve JSON structure when tools return structured data, complementing PR #25's smart truncation feature.

## Problem
Previously, all tool results were flattened into a simplified format:
```json
{
  "success": true,
  "content": "{\"files\": [...], \"stats\": {...}}"  // JSON as string
}
```

This lost the structure of complex tool outputs, making them harder to process and analyze.

## Solution
The MCP client now:
1. Attempts to parse tool text content as JSON
2. If successful, returns the parsed JSON directly to preserve structure
3. Only falls back to the simplified format for non-JSON content

## Example
**Before:**
```json
{
  "success": true,
  "content": "{\"files\": [\"test.py\", \"main.py\"], \"lines\": 500}"
}
```

**After:**
```json
{
  "files": ["test.py", "main.py"],
  "lines": 500
}
```

## Benefits
- **Preserves Structure**: Complex tool outputs maintain their JSON structure
- **Better Integration**: Works seamlessly with PR #25's smart truncation
- **Backward Compatible**: Non-JSON content still uses the simplified format
- **Cleaner Pipeline**: Structured data flows cleanly from tools → MCP → decisions

## Testing
- [x] JSON content is parsed and preserved
- [x] Non-JSON content falls back to simple format
- [x] Invalid JSON falls back gracefully
- [x] Works with smart truncation from PR #25

## Related
- Builds on PR #25 (smart truncation for decision tracking)
- Together they ensure structured tool outputs are preserved and intelligently handled throughout the system