### PR TITLE
ci: remove Magic Nix Cache from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
     
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-    
     - name: Cache cargo registry
       uses: actions/cache@v5
       with:
@@ -88,9 +85,6 @@ jobs:
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes
-    
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
     
     - name: Cache cargo registry
       uses: actions/cache@v5
@@ -141,9 +135,6 @@ jobs:
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes
-    
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
     
     - name: Cache cargo registry
       uses: actions/cache@v5


### PR DESCRIPTION
Removes the `DeterminateSystems/magic-nix-cache-action` step from all workflows — it has been unreliable in CI (rate-limited local substituter). Nix now fetches from `cache.nixos.org` directly; the Nix installer and Cargo registry cache are unchanged.